### PR TITLE
Use wrapper script to build smaller image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ be queried on your local machine.
 
 To rebuild the docker image, run:
 
-    docker load -i `nix-build`
+    nix-build && ./result
 
 To run the Hoogle server:
 

--- a/default.nix
+++ b/default.nix
@@ -2,15 +2,55 @@
 
 let
   hooglePort = "8687";
-  hp = pkgs.haskellPackages.ghcWithHoogle (import ./package-list.nix);
-in
-pkgs.dockerTools.buildImage {
-  name = "jwiegley/hoogle-local";
-  contents = [ hp ];
-  config = {
-    Cmd = [ "${hp}/bin/hoogle" "server" "--local" "-p" "${hooglePort}" ];
-    ExposedPorts = {
-      "${hooglePort}/tcp" = {};
+  hp = (pkgs.haskellPackages.override {
+    overrides = self: super: {
+      hoogle_4_2_43 = super.hoogle_4_2_43.override {
+        mkDerivation = args: super.mkDerivation (args // {
+          enableSharedExecutables = false;
+          #configureFlags = [ "--ghc-option=-optl=-static" "--ghc-option=-optl=-pthread" ];
+        });
+      };
     };
-  };
-}
+  }).ghcWithHoogle (import ./package-list.nix);
+  hoogle = hp.haskellPackages.hoogle_4_2_43;
+  dockerfile = pkgs.writeText "Dockerfile" ''
+    FROM alpine:3.3
+    COPY tmp /
+    EXPOSE ${hooglePort}
+    CMD ["/bin/hoogle", "server", "--local", "-p", "${hooglePort}" ]
+  '';
+in pkgs.writeScript "build.sh" ''
+  #!/${pkgs.stdenv.shell} -e
+
+  export PATH=${pkgs.docker}/bin:${pkgs.gnused}/bin:${pkgs.coreutils}/bin:${pkgs.gnugrep}/bin:${pkgs.cpio}/bin:${pkgs.nix}/bin:$PATH
+
+  # copy docs out of haskellPackages nix closure
+  for thing in $(nix-store -qR ${hp}); do
+      echo "copying $thing"
+      find $thing -depth -print | egrep '\.(hoo|css|js|html|png)' | cpio -pvd tmp
+  done
+
+  # finds the store path of the hoogle local wrapper (not the best way)
+  HOOGLE_LOCAL=$(dirname $(dirname $(readlink ${hp}/bin/hoogle)))
+
+  for thing in ${hp} ${hoogle} ${hp.haskellPackages.ghc.doc} $HOOGLE_LOCAL ${pkgs.glibc} ${pkgs.gmp} ${pkgs.zlib} ${pkgs.stdenv.shell}; do
+      echo "fully copying $thing"
+      find $thing -depth -print | cpio -pvd tmp
+  done
+
+  # install wrapper script in easy-to-inspect place
+  mkdir -p tmp/bin
+  cp -L ${hp}/bin/hoogle tmp/bin
+
+  # files copied from nix store are read-only, fix that
+  chmod -R u+w tmp
+
+  # naughty link fixup -- some browsers don't like file:/// links any more.
+  # hoogle also edits the links to add /file prefix
+  find tmp -type f -name '*.html' -exec sed -i 's=file:///nix/store=/nix/store=g' '{}' ';'
+
+  # Set up a Dockerfile for the docker build of temp directory
+  cp --no-preserve=mode ${dockerfile} tmp-Dockerfile
+  docker build -t jwiegley/hoogle-local -f tmp-Dockerfile .
+  rm -rf tmp tmp-Dockerfile
+''


### PR DESCRIPTION
After some testing I realised that the `dockerTools` method #1 is convenient but it's difficult to prune the image.

dockerTools.buildImage pulls in the "minimal" closure for hoogle as
determined by nix. Problem is:

1. Minimal closure is not small, because haskellPackages dependencies
   aren't very specific (e.g. docs aren't separated from other outputs).

2. It's not possible to manually prune the image in the `runAsRoot`
   phase because it read-only bind-mounts /nix/store.

So we go to a more manual method of plucking the chosen files out the
nix store and using docker to make an image from them.

Hoogle is also statically linked against Haskell libraries (but not
system libraries).

The shell scripting is a bit poor but it works. Image is now 613MB.
